### PR TITLE
[NSO-1186] make mariadb role path defaults match puppet

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,7 @@ mysql_max_connections: 512
 mysql_extra_max_connections: 1
 mysql_max_allowed_packet: "1024M"
 mysql_data_dir: "/var/lib/mysql"
-mysql_pid_file: "/var/run/mysql/mysql.pid"
+mysql_pid_file: "/var/lib/mysql/mysqld.pid"
 mysql_table_open_cache: 256
 mysql_table_definition_cache: 2048
 mysql_open_file_limit: 16384
@@ -45,4 +45,4 @@ mysql_innodb_flush_neighbors: 0
 mysql_innodb_flush_method: "O_DIRECT"
 mysql_innodb_ft_min_token_size: 2
 mysql_innodb_stats_on_metadata: "OFF"
-mysql_log_error: "/var/log/mysql.log"
+mysql_log_error: "/var/log/mysqld.log"


### PR DESCRIPTION
This should fix issues preventing mariadb from restarting correctly after puppet has run.