### PR TITLE
[SOS-1198] | Create error log file for mariadb

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -64,6 +64,11 @@
     group="mysql"
     mode=0755
 
+- name: Check for existence of {{ mysql_log_error }}
+  stat:
+    path="{{ mysql_log_error }}"
+  register: stat_error_log
+
 - name: Creates MySQL Error Log File
   file:
     path="{{ mysql_log_error }}"
@@ -71,6 +76,7 @@
     owner="mysql"
     group="mysql"
     mode=0640
+  when: not stat_error_log.stat.exists
 
 - name: Set Configuration File
   template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -64,6 +64,14 @@
     group="mysql"
     mode=0755
 
+- name: Creates MySQL Error Log File
+  file:
+    path="{{ mysql_log_error }}"
+    state="touch"
+    owner="mysql"
+    group="mysql"
+    mode=0640
+
 - name: Set Configuration File
   template:
     src="my.cnf.j2"


### PR DESCRIPTION
This covers [one out of two parts](https://nexcess.atlassian.net/browse/SOS-1168) of getting mysqld error logs working and rotating on cloudhosts.

Changes:
- Create the error log file (with appropriate perms and ownership) prior to starting the mariadb instance