### PR TITLE
Sun Feb 28 15:15:46 EST 2021 | Update default mariadb version to 10.4

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-mariadb_version: 10.2
+mariadb_version: 10.4
 mysql_upgrade: false
 mysql_port: 3306
 mysql_socket: "/var/lib/mysql/mysql.sock"


### PR DESCRIPTION
## **Description**
Now that a few production cloudhost servers are using MariaDB 10.4 without any reported issues, the next step is to deploy future cloudhosts with 10.4 default. This pull request will bring that change to fruition.

## **Changes**
- Update the mariadb_version variable

## **Testing**

### **Testing that all role default values work with MariaDB 10.4 installation**
<details>
<summary>Click to show results</summary>

**Running ansible to verify that defaults don't cause failure in the MariaDB installation/startup**
~~~bash
[15:49:52][KVM]][el7.install_mariadb_104.vm.jrome741.net][root][/HOME/git/mariadb_role]
$ ansible-playbook -i /HOME/git/mariadb_role/ansible-role-mariadb/hosts --private-key $HOME/.ssh/ansible.key /HOME/git/mariadb_role/ansible-role-mariadb/main.yml

PLAY [localhost] **************************************************************************************************************************************************************************************

TASK [Gathering Facts] ********************************************************************************************************************************************************************************
ok: [localhost]

TASK [See if Default MariaDB Exists] ******************************************************************************************************************************************************************
[WARNING]: Consider using the yum, dnf or zypper module rather than running 'rpm'.  If you need to use command because yum, dnf or zypper is insufficient you can add 'warn: false' to this command
task or set 'command_warnings=False' in ansible.cfg to get rid of this message.
changed: [localhost]

TASK [Stop MariaDB if Installed] **********************************************************************************************************************************************************************
skipping: [localhost]

TASK [Remove Existing MariaDB Install] ****************************************************************************************************************************************************************
[DEPRECATION WARNING]: Invoking "yum" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and specifying `name: "{{ item }}"`, please use
`name: ['MariaDB', 'MariaDB-server', 'mysql-libs']` and remove the loop. This feature will be removed in version 2.11. Deprecation warnings can be disabled by setting deprecation_warnings=False in
ansible.cfg.
ok: [localhost] => (item=[u'MariaDB', u'MariaDB-server', u'mysql-libs'])

TASK [Allow MariaDB Port(s) In SELinux] ***************************************************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ImportError: No module named semanage
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Failed to import the required Python library (libsemanage-python) on el7.install_mariadb_104.vm.jrome741.net's Python /usr/bin/python. Please
 read module documentation and install in the appropriate location. If the required library is installed, but Ansible is using the wrong Python interpreter, please consult the documentation on ansibl
e_python_interpreter"}
...ignoring

TASK [Explicitly Allow mysql_extra_port] **************************************************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ImportError: No module named seobject
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Failed to import the required Python library (policycoreutils-python) on el7.install_mariadb_104.vm.jrome741.net's Python /usr/bin/python. Pl
ease read module documentation and install in the appropriate location. If the required library is installed, but Ansible is using the wrong Python interpreter, please consult the documentation on an
sible_python_interpreter"}
...ignoring

TASK [Flush Yum Cache] ********************************************************************************************************************************************************************************
[WARNING]: Consider using the yum module rather than running 'yum'.  If you need to use command because yum is insufficient you can add 'warn: false' to this command task or set
'command_warnings=False' in ansible.cfg to get rid of this message.
changed: [localhost]

TASK [Add MariaDB Repo] *******************************************************************************************************************************************************************************
ok: [localhost]

TASK [Install MariaDB] ********************************************************************************************************************************************************************************
[DEPRECATION WARNING]: Invoking "yum" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and specifying `name: "{{ item }}"`, please use
`name: ['MariaDB-server', 'MariaDB-client', 'mysql-libs']` and remove the loop. This feature will be removed in version 2.11. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.
changed: [localhost] => (item=[u'MariaDB-server', u'MariaDB-client', u'mysql-libs'])

TASK [Creates PID Directory] **************************************************************************************************************************************************************************
ok: [localhost]

TASK [Check for existence of /var/log/mysqld.log] *****************************************************************************************************************************************************
ok: [localhost]

TASK [Creates MySQL Error Log File] *******************************************************************************************************************************************************************
changed: [localhost]

TASK [Set Configuration File] *************************************************************************************************************************************************************************
changed: [localhost]

TASK [Enable MariaDB] *********************************************************************************************************************************************************************************
changed: [localhost]

TASK [MySQL Upgrade] **********************************************************************************************************************************************************************************
skipping: [localhost]

PLAY RECAP ********************************************************************************************************************************************************************************************
localhost                  : ok=13   changed=6    unreachable=0    failed=0    skipped=2    rescued=0    ignored=2
~~~

**Installed version of MariaDB**
~~~bash
[15:50:57][KVM]][el7.install_mariadb_104.vm.jrome741.net][root][/HOME/git/mariadb_role]
$ mysql
Welcome to the MariaDB monitor.  Commands end with ; or \g.
Your MariaDB connection id is 8
Server version: 10.4.18-MariaDB MariaDB Server

Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

MariaDB [(none)]> Bye
~~~

</details>

## **Misc**
- [SOS Jira item](https://liquidweb.atlassian.net/browse/SOS-1690) pertaining to MariaDB Upgrades
- [Maintenance window](https://nocworx.nexcess.net/maintenance-window/3535) pertaining to first batch of MariaDB Upgrades
