### PR TITLE
Revert "Sun Feb 28 15:15:46 EST 2021 | Update default mariadb version to 10.4"

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-mariadb_version: 10.4
+mariadb_version: 10.2
 mysql_upgrade: false
 mysql_port: 3306
 mysql_socket: "/var/lib/mysql/mysql.sock"


### PR DESCRIPTION
Reverts nexcess/ansible-role-mariadb#17