### PR TITLE
Mon Mar 22 14:15:53 EDT 2021 | Install MariaDB10.3 on new cloudhosts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-mariadb_version: 10.2
+mariadb_version: 10.3
 mysql_upgrade: false
 mysql_port: 3306
 mysql_socket: "/var/lib/mysql/mysql.sock"


### PR DESCRIPTION
## **Description**
Moving forward we plan on installing MariaDB 10.3 on new cloudhosts. This is to test the installation on QA Prod and make sure that there aren't any issues within portal / plan creation  

## **Changes**
- Update MariaDB installation version to 10.3 (from 10.2)
