### PR TITLE
Tue Oct 25 12:07:06 EDT 2022 | Update baseurl and gpg key URLs

### DIFF
--- a/templates/mariadb_centos.repo.j2
+++ b/templates/mariadb_centos.repo.j2
@@ -2,6 +2,6 @@
 # http://downloads.mariadb.org/mariadb/repositories/
 [mariadb]
 name = MariaDB
-baseurl = http://yum.mariadb.org/{{ mariadb_version }}/centos{{ ansible_distribution_major_version|int }}-amd64
-gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
+baseurl = http://mirror.mariadb.org/yum/{{ mariadb_version }}/centos{{ ansible_distribution_major_version|int }}-amd64
+gpgkey=https://mirror.mariadb.org/yum/RPM-GPG-KEY-MariaDB
 gpgcheck=1


### PR DESCRIPTION
## **Description**
MariaDB has updated the location of their GPG card. From the sounds of the Jira card (linked below), yum is not able to follow the `Location` header. This pull request explicitly sets the new location

## **Changes**
- Update the gpgkey location in the repo filie
- Update the baseurl location in the repo file

## **Testing**

### **<edit here>**
<details>
<summary>Click to show results</summary>

</details>

## **Misc**
- **[[JIra](https://liquidweb.atlassian.net/browse/NSE-15473)]** Related Jira item